### PR TITLE
Add repo and license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
   },
   "devDependencies": {
     "electron-packager": "^5.0.1"
-  }
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "devDependencies": {
     "electron-packager": "^5.0.1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Bahlaouane-Hamza/Yays"
+  }
 }


### PR DESCRIPTION
Will get rid of this set of warnings:

<img width="521" alt="screen shot 2015-10-30 at 7 37 46 pm" src="https://cloud.githubusercontent.com/assets/9198315/10860865/baebfe20-7f3d-11e5-9e2d-9945e981ee00.png">
